### PR TITLE
Changed raise to raise exception

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -283,7 +283,7 @@ class Stream(object):
         if exception:
             # call a handler first so that the exception can be logged.
             self.listener.on_exception(exception)
-            raise
+            raise exception
 
     def _data(self, data):
         if self.listener.on_data(data) is False:


### PR DESCRIPTION
Line 286.

This prevents the "RuntimeError: No active exception to reraise" error.

http://stackoverflow.com/a/28871066

Didn't look like anyone had changed the line.